### PR TITLE
PHP 5.3.3 is the least required for PHPUnit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "type": "library",
     "description": "Detecting the user's browser, operating system and language.",
     "keywords": ["browser", "os", "operating system", "language", "detection"],
-    "homepage": "https://github.com/gabrielbull/php-browser",
     "license": "MIT",
     "authors": [
         {
@@ -17,10 +16,10 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0"
+        "php": ">=5.3.3"
     },
     "require-dev": {
-        "phpunit/phpunit": "~4"
+        "phpunit/phpunit": "~4.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Also removed homepage since the repository is the default value.