### PR TITLE
Fix syntax errors

### DIFF
--- a/src/Browser/AcceptLanguage.php
+++ b/src/Browser/AcceptLanguage.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser;
 
 class AcceptLanguage
@@ -20,11 +21,13 @@ class AcceptLanguage
 
     /**
      * @param string $acceptLanguageString
+     *
      * @return $this
      */
     public function setAcceptLanguageString($acceptLanguageString)
     {
         $this->acceptLanguageString = $acceptLanguageString;
+
         return $this;
     }
 
@@ -36,6 +39,7 @@ class AcceptLanguage
         if (null === $this->acceptLanguageString) {
             $this->createAcceptLanguageString();
         }
+
         return $this->acceptLanguageString;
     }
 
@@ -46,6 +50,7 @@ class AcceptLanguage
     {
         $acceptLanguageString = isset($_SERVER['HTTP_ACCEPT_LANGUAGE']) ? $_SERVER['HTTP_ACCEPT_LANGUAGE'] : null;
         $this->setAcceptLanguageString($acceptLanguageString);
+
         return $acceptLanguageString;
     }
 }

--- a/src/Browser/Browser.php
+++ b/src/Browser/Browser.php
@@ -1,10 +1,9 @@
 <?php
+
 namespace Browser;
 
 /**
- * Browser Detection
- *
- * @package browser
+ * Browser Detection.
  */
 class Browser
 {
@@ -73,6 +72,7 @@ class Browser
 
     /**
      * @param null|string|UserAgent $userAgent
+     *
      * @throws \Browser\InvalidArgumentException
      */
     public function __construct($userAgent = null)
@@ -82,7 +82,7 @@ class Browser
         } elseif (null === $userAgent || is_string($userAgent)) {
             $this->setUserAgent(new UserAgent($userAgent));
         } else {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException();
         }
     }
 
@@ -90,11 +90,13 @@ class Browser
      * Set the name of the OS.
      *
      * @param string $name
+     *
      * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -108,13 +110,15 @@ class Browser
         if (!isset($this->name)) {
             BrowserDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->name;
     }
 
     /**
-     * Check to see if the specific browser is valid
+     * Check to see if the specific browser is valid.
      *
      * @param string $name
+     *
      * @return bool
      */
     public function isBrowser($name)
@@ -123,14 +127,16 @@ class Browser
     }
 
     /**
-     * Set the version of the browser
+     * Set the version of the browser.
      *
      * @param string $version
+     *
      * @return $this
      */
     public function setVersion($version)
     {
         $this->version = $version;
+
         return $this;
     }
 
@@ -144,18 +150,21 @@ class Browser
         if (!isset($this->name)) {
             BrowserDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->version;
     }
 
     /**
-     * Set the Browser to be a robot
+     * Set the Browser to be a robot.
      *
      * @param bool $isRobot
+     *
      * @return $this
      */
     public function setIsRobot($isRobot)
     {
-        $this->isRobot = (bool)$isRobot;
+        $this->isRobot = (bool) $isRobot;
+
         return $this;
     }
 
@@ -169,6 +178,7 @@ class Browser
         if (!isset($this->name)) {
             BrowserDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->isRobot;
     }
 
@@ -182,16 +192,18 @@ class Browser
 
     /**
      * @param bool $isChromeFrame
+     *
      * @return $this
      */
     public function setIsChromeFrame($isChromeFrame)
     {
-        $this->isChromeFrame = (bool)$isChromeFrame;
+        $this->isChromeFrame = (bool) $isChromeFrame;
+
         return $this;
     }
 
     /**
-     * Used to determine if the browser is actually "chromeframe"
+     * Used to determine if the browser is actually "chromeframe".
      *
      * @return bool
      */
@@ -200,6 +212,7 @@ class Browser
         if (!isset($this->name)) {
             BrowserDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->isChromeFrame;
     }
 
@@ -213,11 +226,13 @@ class Browser
 
     /**
      * @param UserAgent $userAgent
+     *
      * @return $this
      */
     public function setUserAgent(UserAgent $userAgent)
     {
         $this->userAgent = $userAgent;
+
         return $this;
     }
 

--- a/src/Browser/BrowserDetector.php
+++ b/src/Browser/BrowserDetector.php
@@ -1,9 +1,9 @@
 <?php
+
 namespace Browser;
 
 class BrowserDetector implements DetectorInterface
 {
-
     const FUNC_PREFIX = 'checkBrowser';
 
     protected static $userAgentString;
@@ -62,11 +62,11 @@ class BrowserDetector implements DetectorInterface
         'Shiretoko',
         'IceCat',
         'Iceweasel',
-        'Mozilla' /* Mozilla is such an open standard that you must check it last */
+        'Mozilla', /* Mozilla is such an open standard that you must check it last */
     );
 
     /**
-     * Routine to determine the browser type
+     * Routine to determine the browser type.
      *
      * @param Browser $browser
      * @param UserAgent $userAgent
@@ -87,7 +87,7 @@ class BrowserDetector implements DetectorInterface
         self::checkChromeFrame();
 
         foreach (self::$browsersList as $browserName) {
-            $funcName = self::FUNC_PREFIX . $browserName;
+            $funcName = self::FUNC_PREFIX.$browserName;
 
             if (self::$funcName()) {
                 return true;
@@ -104,10 +104,12 @@ class BrowserDetector implements DetectorInterface
      */
     public static function checkChromeFrame()
     {
-        if (strpos(self::$userAgentString, "chromeframe") !== false) {
+        if (strpos(self::$userAgentString, 'chromeframe') !== false) {
             self::$browser->setIsChromeFrame(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -119,12 +121,14 @@ class BrowserDetector implements DetectorInterface
     public static function checkBrowserBlackBerry()
     {
         if (stripos(self::$userAgentString, 'blackberry') !== false) {
-            $aresult = explode("/", stristr(self::$userAgentString, "BlackBerry"));
+            $aresult = explode('/', stristr(self::$userAgentString, 'BlackBerry'));
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::BLACKBERRY);
+
             return true;
         }
+
         return false;
     }
 
@@ -141,8 +145,10 @@ class BrowserDetector implements DetectorInterface
             stripos(self::$userAgentString, 'crawler') !== false
         ) {
             self::$browser->setIsRobot(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -161,6 +167,7 @@ class BrowserDetector implements DetectorInterface
             if (preg_match('/308|425|426|474|0b1/i', $aresult)) {
                 self::$browser->setVersion('1.5');
             }
+
             return true;
         } // Test for versions > 1.5 and < 11 and some cases of 11
         else {
@@ -171,6 +178,7 @@ class BrowserDetector implements DetectorInterface
                     $aresult = explode(' ', stristr(str_replace(';', '; ', self::$userAgentString), 'MSN'));
                     self::$browser->setName(Browser::MSN);
                     self::$browser->setVersion(str_replace(array('(', ')', ';'), '', $aresult[1]));
+
                     return true;
                 }
                 $aresult = explode(' ', stristr(str_replace(';', '; ', self::$userAgentString), 'msie'));
@@ -184,6 +192,7 @@ class BrowserDetector implements DetectorInterface
                         self::$browser->setVersion($matches[1]);
                     }
                 }
+
                 return true;
             } // Test for versions >= 11
             else {
@@ -193,6 +202,7 @@ class BrowserDetector implements DetectorInterface
                     preg_match('/rv:(\d+\.\d+)/', self::$userAgentString, $matches);
                     if (isset($matches[1])) {
                         self::$browser->setVersion($matches[1]);
+
                         return true;
                     } else {
                         return false;
@@ -211,11 +221,13 @@ class BrowserDetector implements DetectorInterface
                             $aversion = explode('/', self::$userAgentString);
                             self::$browser->setVersion($aversion[1]);
                         }
+
                         return true;
                     }
                 }
             }
         }
+
         return false;
     }
 
@@ -237,34 +249,39 @@ class BrowserDetector implements DetectorInterface
                 self::$browser->setVersion($aversion[1]);
             }
             self::$browser->setName(Browser::OPERA_MINI);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'OPiOS') !== false) {
             $aresult = explode('/', stristr(self::$userAgentString, 'OPiOS'));
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::OPERA_MINI);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'opera') !== false) {
             $resultant = stristr(self::$userAgentString, 'opera');
             if (preg_match('/Version\/(1[0-2].*)$/', $resultant, $matches)) {
                 self::$browser->setVersion($matches[1]);
             } elseif (preg_match('/\//', $resultant)) {
-                $aresult = explode('/', str_replace("(", " ", $resultant));
+                $aresult = explode('/', str_replace('(', ' ', $resultant));
                 $aversion = explode(' ', $aresult[1]);
                 self::$browser->setVersion($aversion[0]);
             } else {
                 $aversion = explode(' ', stristr($resultant, 'opera'));
-                self::$browser->setVersion(isset($aversion[1]) ? $aversion[1] : "");
+                self::$browser->setVersion(isset($aversion[1]) ? $aversion[1] : '');
             }
             self::$browser->setName(Browser::OPERA);
+
             return true;
         } elseif (stripos(self::$userAgentString, ' OPR/') !== false) {
             self::$browser->setName(Browser::OPERA);
             if (preg_match('/OPR\/([\d\.]*)/', self::$userAgentString, $matches)) {
                 self::$browser->setVersion($matches[1]);
             }
+
             return true;
         }
+
         return false;
     }
 
@@ -280,12 +297,14 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::CHROME);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'CriOS') !== false) {
             $aresult = explode('/', stristr(self::$userAgentString, 'CriOS'));
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::CHROME);
+
             return true;
         }
 
@@ -301,9 +320,10 @@ class BrowserDetector implements DetectorInterface
         if (stripos(self::$userAgentString, 'Edge') !== false) {
             $version = explode('Edge/', self::$userAgentString);
             if (isset($version[1])) {
-                self::$browser->setVersion((float)$version[1]);
+                self::$browser->setVersion((float) $version[1]);
             }
             self::$browser->setName(Browser::EDGE);
+
             return true;
         }
 
@@ -322,6 +342,7 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::GSA);
+
             return true;
         }
 
@@ -340,8 +361,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::WEBTV);
+
             return true;
         }
+
         return false;
     }
 
@@ -357,8 +380,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion(str_replace(array('(', ')', ';'), '', $aversion[0]));
             self::$browser->setName(Browser::NETPOSITIVE);
+
             return true;
         }
+
         return false;
     }
 
@@ -374,8 +399,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode('/', $aresult[0]);
             self::$browser->setVersion($aversion[1]);
             self::$browser->setName(Browser::GALEON);
+
             return true;
         }
+
         return false;
     }
 
@@ -391,8 +418,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode('/', $aresult[0]);
             self::$browser->setVersion($aversion[1]);
             self::$browser->setName(Browser::KONQUEROR);
+
             return true;
         }
+
         return false;
     }
 
@@ -407,8 +436,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', stristr(str_replace('/', ' ', self::$userAgentString), 'icab'));
             self::$browser->setVersion($aversion[1]);
             self::$browser->setName(Browser::ICAB);
+
             return true;
         }
+
         return false;
     }
 
@@ -421,11 +452,13 @@ class BrowserDetector implements DetectorInterface
     {
         if (stripos(self::$userAgentString, 'omniweb') !== false) {
             $aresult = explode('/', stristr(self::$userAgentString, 'omniweb'));
-            $aversion = explode(' ', isset($aresult[1]) ? $aresult[1] : "");
+            $aversion = explode(' ', isset($aresult[1]) ? $aresult[1] : '');
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::OMNIWEB);
+
             return true;
         }
+
         return false;
     }
 
@@ -440,8 +473,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode('/', stristr(self::$userAgentString, 'Phoenix'));
             self::$browser->setVersion($aversion[1]);
             self::$browser->setName(Browser::PHOENIX);
+
             return true;
         }
+
         return false;
     }
 
@@ -456,8 +491,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode('/', stristr(self::$userAgentString, 'Firebird'));
             self::$browser->setVersion($aversion[1]);
             self::$browser->setName(Browser::FIREBIRD);
+
             return true;
         }
+
         return false;
     }
 
@@ -473,14 +510,17 @@ class BrowserDetector implements DetectorInterface
         ) {
             self::$browser->setVersion($matches[1]);
             self::$browser->setName(Browser::NETSCAPE_NAVIGATOR);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'Firefox') === false && preg_match('/Netscape6?\/([^ ]*)/i',
                 self::$userAgentString, $matches)
         ) {
             self::$browser->setVersion($matches[1]);
             self::$browser->setName(Browser::NETSCAPE_NAVIGATOR);
+
             return true;
         }
+
         return false;
     }
 
@@ -496,8 +536,10 @@ class BrowserDetector implements DetectorInterface
         ) {
             self::$browser->setVersion($matches[1]);
             self::$browser->setName(Browser::SHIRETOKO);
+
             return true;
         }
+
         return false;
     }
 
@@ -513,8 +555,10 @@ class BrowserDetector implements DetectorInterface
         ) {
             self::$browser->setVersion($matches[1]);
             self::$browser->setName(Browser::ICECAT);
+
             return true;
         }
+
         return false;
     }
 
@@ -534,8 +578,10 @@ class BrowserDetector implements DetectorInterface
             } else {
                 self::$browser->setName(Browser::NOKIA);
             }
+
             return true;
         }
+
         return false;
     }
 
@@ -550,13 +596,16 @@ class BrowserDetector implements DetectorInterface
             if (preg_match("/Firefox[\/ \(]([^ ;\)]+)/i", self::$userAgentString, $matches)) {
                 self::$browser->setVersion($matches[1]);
                 self::$browser->setName(Browser::FIREFOX);
+
                 return true;
-            } elseif (preg_match("/Firefox$/i", self::$userAgentString, $matches)) {
-                self::$browser->setVersion("");
+            } elseif (preg_match('/Firefox$/i', self::$userAgentString, $matches)) {
+                self::$browser->setVersion('');
                 self::$browser->setName(Browser::FIREFOX);
+
                 return true;
             }
         }
+
         return false;
     }
 
@@ -571,13 +620,16 @@ class BrowserDetector implements DetectorInterface
             if (preg_match("/SeaMonkey[\/ \(]([^ ;\)]+)/i", self::$userAgentString, $matches)) {
                 self::$browser->setVersion($matches[1]);
                 self::$browser->setName(Browser::SEAMONKEY);
+
                 return true;
-            } elseif (preg_match("/SeaMonkey$/i", self::$userAgentString, $matches)) {
-                self::$browser->setVersion("");
+            } elseif (preg_match('/SeaMonkey$/i', self::$userAgentString, $matches)) {
+                self::$browser->setVersion('');
                 self::$browser->setName(Browser::SEAMONKEY);
+
                 return true;
             }
         }
+
         return false;
     }
 
@@ -593,8 +645,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::ICEWEASEL);
+
             return true;
         }
+
         return false;
     }
 
@@ -612,6 +666,7 @@ class BrowserDetector implements DetectorInterface
             preg_match('/rv:[0-9].[0-9][a-b]?/i', self::$userAgentString, $aversion);
             self::$browser->setVersion(str_replace('rv:', '', $aversion[0]));
             self::$browser->setName(Browser::MOZILLA);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'mozilla') !== false && preg_match('/rv:[0-9]\.[0-9]/i',
                 self::$userAgentString) && stripos(self::$userAgentString, 'netscape') === false
@@ -619,14 +674,17 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode('', stristr(self::$userAgentString, 'rv:'));
             self::$browser->setVersion(str_replace('rv:', '', $aversion[0]));
             self::$browser->setName(Browser::MOZILLA);
+
             return true;
         } elseif (stripos(self::$userAgentString, 'mozilla') !== false && preg_match('/mozilla\/([^ ]*)/i',
                 self::$userAgentString, $matches) && stripos(self::$userAgentString, 'netscape') === false
         ) {
             self::$browser->setVersion($matches[1]);
             self::$browser->setName(Browser::MOZILLA);
+
             return true;
         }
+
         return false;
     }
 
@@ -639,11 +697,13 @@ class BrowserDetector implements DetectorInterface
     {
         if (stripos(self::$userAgentString, 'lynx') !== false) {
             $aresult = explode('/', stristr(self::$userAgentString, 'Lynx'));
-            $aversion = explode(' ', (isset($aresult[1]) ? $aresult[1] : ""));
+            $aversion = explode(' ', (isset($aresult[1]) ? $aresult[1] : ''));
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::LYNX);
+
             return true;
         }
+
         return false;
     }
 
@@ -659,8 +719,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::AMAYA);
+
             return true;
         }
+
         return false;
     }
 
@@ -680,8 +742,10 @@ class BrowserDetector implements DetectorInterface
                 self::$browser->setVersion(Browser::VERSION_UNKNOWN);
             }
             self::$browser->setName(Browser::SAFARI);
+
             return true;
         }
+
         return false;
     }
 
@@ -697,8 +761,10 @@ class BrowserDetector implements DetectorInterface
             $aversion = explode(' ', $aresult[1]);
             self::$browser->setVersion($aversion[0]);
             self::$browser->setName(Browser::YANDEX);
+
             return true;
         }
+
         return false;
     }
 
@@ -717,8 +783,10 @@ class BrowserDetector implements DetectorInterface
                 self::$browser->setVersion(Browser::VERSION_UNKNOWN);
             }
             self::$browser->setName(Browser::NAVIGATOR);
+
             return true;
         }
+
         return false;
     }
 }

--- a/src/Browser/DetectorInterface.php
+++ b/src/Browser/DetectorInterface.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser;
 
 interface DetectorInterface

--- a/src/Browser/Device.php
+++ b/src/Browser/Device.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser;
 
 class Device
@@ -20,7 +21,7 @@ class Device
     private $version = self::UNKNOWN_VERSION;
 
     /**
-     * @var boolean
+     * @var bool
      */
     private $isDetected = false;
 
@@ -33,16 +34,19 @@ class Device
             $detector = (new DeviceDetector());
             $detector->detect($this);
         }
+
         return $this->name;
     }
 
     /**
      * @param string $name
+     *
      * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -56,16 +60,18 @@ class Device
 
     /**
      * @param string $version
+     *
      * @return $this
      */
     public function setVersion($version)
     {
         $this->version = $version;
+
         return $this;
     }
 
     /**
-     * @return boolean
+     * @return bool
      */
     public function isDetected()
     {
@@ -73,12 +79,14 @@ class Device
     }
 
     /**
-     * @param boolean $isDetected
+     * @param bool $isDetected
+     *
      * @return $this
      */
     public function setIsDetected($isDetected)
     {
         $this->isDetected = $isDetected;
+
         return $this;
     }
 }

--- a/src/Browser/DeviceDetector.php
+++ b/src/Browser/DeviceDetector.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser;
 
 class DeviceDetector implements DetectorInterface
@@ -15,6 +16,7 @@ class DeviceDetector implements DetectorInterface
 
     /**
      * @param null|Device $device
+     *
      * @throws \Browser\InvalidArgumentException
      */
     public function detect(Device $device)
@@ -38,21 +40,26 @@ class DeviceDetector implements DetectorInterface
     {
         if (stripos($this->userAgent->getUserAgentString(), 'ipad') !== false) {
             $this->device->setName(Device::IPAD);
+
             return true;
         }
+
         return false;
     }
 
     /**
-     * Determine if the device is Iphone
+     * Determine if the device is Iphone.
+     *
      * @return bool
      */
     public function checkIphone()
     {
         if (stripos($this->userAgent->getUserAgentString(), 'iphone;') !== false) {
             $this->device->setName(Device::IPHONE);
+
             return true;
         }
+
         return false;
     }
 
@@ -66,11 +73,13 @@ class DeviceDetector implements DetectorInterface
 
     /**
      * @param Device $device
+     *
      * @return $this
      */
     public function setDevice(Device $device)
     {
         $this->device = $device;
+
         return $this;
     }
 
@@ -84,11 +93,13 @@ class DeviceDetector implements DetectorInterface
 
     /**
      * @param UserAgent $userAgent
+     *
      * @return $this
      */
     public function setUserAgent(UserAgent $userAgent)
     {
         $this->userAgent = $userAgent;
+
         return $this;
     }
 }

--- a/src/Browser/InvalidArgumentException.php
+++ b/src/Browser/InvalidArgumentException.php
@@ -2,7 +2,6 @@
 
 namespace Browser;
 
-
-class InvalidArgumentException extends \InvalidArgumentException {
-
+class InvalidArgumentException extends \InvalidArgumentException
+{
 }

--- a/src/Browser/Language.php
+++ b/src/Browser/Language.php
@@ -1,10 +1,9 @@
 <?php
+
 namespace Browser;
 
 /**
- * Language Detection
- *
- * @package browser
+ * Language Detection.
  */
 class Language
 {
@@ -20,6 +19,7 @@ class Language
 
     /**
      * @param null|string|AcceptLanguage $acceptLanguage
+     *
      * @throws \Browser\InvalidArgumentException
      */
     public function __construct($acceptLanguage = null)
@@ -29,12 +29,12 @@ class Language
         } elseif (null === $acceptLanguage || is_string($acceptLanguage)) {
             $this->setAcceptLanguage(new AcceptLanguage($acceptLanguage));
         } else {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException();
         }
     }
 
     /**
-     * Get all user's languages
+     * Get all user's languages.
      *
      * @return array
      */
@@ -51,16 +51,18 @@ class Language
      * Set languages.
      *
      * @param string $languages
+     *
      * @return $this
      */
     public function setLanguages($languages)
     {
         $this->languages = $languages;
+
         return $this;
     }
 
     /**
-     * Get a user's language
+     * Get a user's language.
      *
      * @return string
      */
@@ -74,9 +76,10 @@ class Language
     }
 
     /**
-     * Get a user's language and locale
+     * Get a user's language and locale.
      *
      * @param string $separator
+     *
      * @return string
      */
     public function getLanguageLocale($separator = '-')
@@ -94,7 +97,7 @@ class Language
         }
 
         if (!empty($locale)) {
-            return $userLanguage . $separator . strtoupper($locale);
+            return $userLanguage.$separator.strtoupper($locale);
         } else {
             return $userLanguage;
         }
@@ -102,11 +105,13 @@ class Language
 
     /**
      * @param AcceptLanguage $acceptLanguage
+     *
      * @return $this
      */
     public function setAcceptLanguage(AcceptLanguage $acceptLanguage)
     {
         $this->acceptLanguage = $acceptLanguage;
+
         return $this;
     }
 

--- a/src/Browser/LanguageDetector.php
+++ b/src/Browser/LanguageDetector.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace Browser;
 
 class LanguageDetector implements DetectorInterface
 {
     /**
-     * Detect a user's languages and order them by priority
+     * Detect a user's languages and order them by priority.
      *
      * @param Language $language
      * @param AcceptLanguage $acceptLanguage
+     *
      * @return bool
      */
     public static function detect(Language $language, AcceptLanguage $acceptLanguage)

--- a/src/Browser/Os.php
+++ b/src/Browser/Os.php
@@ -1,10 +1,9 @@
 <?php
+
 namespace Browser;
 
 /**
- * OS Detection
- *
- * @package browser
+ * OS Detection.
  */
 class Os
 {
@@ -49,6 +48,7 @@ class Os
 
     /**
      * @param null|string|UserAgent $userAgent
+     *
      * @throws \Browser\InvalidArgumentException
      */
     public function __construct($userAgent = null)
@@ -58,7 +58,7 @@ class Os
         } elseif (null === $userAgent || is_string($userAgent)) {
             $this->setUserAgent(new UserAgent($userAgent));
         } else {
-            throw new InvalidArgumentException;
+            throw new InvalidArgumentException();
         }
     }
 
@@ -72,6 +72,7 @@ class Os
         if (!isset($this->name)) {
             OsDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->name;
     }
 
@@ -79,11 +80,13 @@ class Os
      * Set the name of the OS.
      *
      * @param string $name
+     *
      * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
         return $this;
     }
 
@@ -98,6 +101,7 @@ class Os
             return $this->version;
         } else {
             OsDetector::detect($this, $this->getUserAgent());
+
             return $this->version;
         }
     }
@@ -106,11 +110,13 @@ class Os
      * Set the version of the OS.
      *
      * @param string $version
+     *
      * @return $this
      */
     public function setVersion($version)
     {
         $this->version = $version;
+
         return $this;
     }
 
@@ -124,6 +130,7 @@ class Os
         if (!isset($this->name)) {
             OsDetector::detect($this, $this->getUserAgent());
         }
+
         return $this->isMobile;
     }
 
@@ -136,22 +143,24 @@ class Os
     }
 
     /**
-     * Set the Browser to be mobile
+     * Set the Browser to be mobile.
      *
      * @param bool $isMobile
      */
     public function setIsMobile($isMobile = true)
     {
-        $this->isMobile = (bool)$isMobile;
+        $this->isMobile = (bool) $isMobile;
     }
 
     /**
      * @param UserAgent $userAgent
+     *
      * @return $this
      */
     public function setUserAgent(UserAgent $userAgent)
     {
         $this->userAgent = $userAgent;
+
         return $this;
     }
 

--- a/src/Browser/OsDetector.php
+++ b/src/Browser/OsDetector.php
@@ -1,13 +1,15 @@
 <?php
+
 namespace Browser;
 
 class OsDetector implements DetectorInterface
 {
     /**
-     * Determine the user's operating system
+     * Determine the user's operating system.
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     public static function detect(Os $os, UserAgent $userAgent)
@@ -44,6 +46,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     public static function checkMobileBrowsers(Os $os, UserAgent $userAgent)
@@ -52,7 +55,7 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'opera mini') !== false) {
             $os->setIsMobile(true);
         } // Set is mobile for Pocket IE
-        else if (stripos($userAgent->getUserAgentString(), 'mspie') !== false || stripos($userAgent->getUserAgentString(), 'pocket') !== false) {
+        elseif (stripos($userAgent->getUserAgentString(), 'mspie') !== false || stripos($userAgent->getUserAgentString(), 'pocket') !== false) {
             $os->setIsMobile(true);
         }
     }
@@ -62,6 +65,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkIOS(Os $os, UserAgent $userAgent)
@@ -72,8 +76,10 @@ class OsDetector implements DetectorInterface
                 $os->setVersion(str_replace('_', '.', $matches[2]));
             }
             $os->setIsMobile(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -82,6 +88,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkOSX(Os $os, UserAgent $userAgent)
@@ -91,17 +98,19 @@ class OsDetector implements DetectorInterface
             if (preg_match('/OS X ([\d\._]*)/i', $userAgent->getUserAgentString(), $matches)) {
                 $os->setVersion(str_replace('_', '.', $matches[1]));
             }
+
             return true;
         }
+
         return false;
     }
-
 
     /**
      * Determine if the user's operating system is Windows.
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkWindows(Os $os, UserAgent $userAgent)
@@ -136,9 +145,10 @@ class OsDetector implements DetectorInterface
                         break;
                 }
             }
+
             return true;
         } // Windows Me, Windows 98, Windows 95, Windows CE
-        else if (preg_match('/(Windows 98; Win 9x 4\.90|Windows 98|Windows 95|Windows CE)/i', $userAgent->getUserAgentString(), $matches)) {
+        elseif (preg_match('/(Windows 98; Win 9x 4\.90|Windows 98|Windows 95|Windows CE)/i', $userAgent->getUserAgentString(), $matches)) {
             $os->setName($os::WINDOWS);
             switch (strtolower($matches[0])) {
                 case 'windows 98; win 9x 4.90':
@@ -154,6 +164,7 @@ class OsDetector implements DetectorInterface
                     $os->setVersion('CE');
                     break;
             }
+
             return true;
         }
 
@@ -165,14 +176,17 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkSymbOS(Os $os, UserAgent $userAgent)
     {
         if (stripos($userAgent->getUserAgentString(), 'SymbOS') !== false) {
             $os->setName($os::SYMBOS);
+
             return true;
         }
+
         return false;
     }
 
@@ -181,6 +195,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkLinux(Os $os, UserAgent $userAgent)
@@ -188,8 +203,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'Linux') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::LINUX);
+
             return true;
         }
+
         return false;
     }
 
@@ -198,6 +215,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkNokia(Os $os, UserAgent $userAgent)
@@ -206,8 +224,10 @@ class OsDetector implements DetectorInterface
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::NOKIA);
             $os->setIsMobile(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -216,6 +236,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkBlackBerry(Os $os, UserAgent $userAgent)
@@ -224,8 +245,10 @@ class OsDetector implements DetectorInterface
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::BLACKBERRY);
             $os->setIsMobile(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -234,6 +257,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkAndroid(Os $os, UserAgent $userAgent)
@@ -246,8 +270,10 @@ class OsDetector implements DetectorInterface
             }
             $os->setName($os::ANDROID);
             $os->setIsMobile(true);
+
             return true;
         }
+
         return false;
     }
 
@@ -256,6 +282,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkFreeBSD(Os $os, UserAgent $userAgent)
@@ -263,8 +290,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'FreeBSD') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::FREEBSD);
+
             return true;
         }
+
         return false;
     }
 
@@ -273,6 +302,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkOpenBSD(Os $os, UserAgent $userAgent)
@@ -280,8 +310,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'OpenBSD') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::OPENBSD);
+
             return true;
         }
+
         return false;
     }
 
@@ -290,6 +322,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkSunOS(Os $os, UserAgent $userAgent)
@@ -297,8 +330,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'SunOS') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::SUNOS);
+
             return true;
         }
+
         return false;
     }
 
@@ -307,6 +342,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkNetBSD(Os $os, UserAgent $userAgent)
@@ -314,8 +350,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'NetBSD') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::NETBSD);
+
             return true;
         }
+
         return false;
     }
 
@@ -324,6 +362,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkOpenSolaris(Os $os, UserAgent $userAgent)
@@ -331,8 +370,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'OpenSolaris') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::OPENSOLARIS);
+
             return true;
         }
+
         return false;
     }
 
@@ -341,6 +382,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkOS2(Os $os, UserAgent $userAgent)
@@ -348,8 +390,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'OS\/2') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::OS2);
+
             return true;
         }
+
         return false;
     }
 
@@ -358,6 +402,7 @@ class OsDetector implements DetectorInterface
      *
      * @param Os $os
      * @param UserAgent $userAgent
+     *
      * @return bool
      */
     private static function checkBeOS(Os $os, UserAgent $userAgent)
@@ -365,8 +410,10 @@ class OsDetector implements DetectorInterface
         if (stripos($userAgent->getUserAgentString(), 'BeOS') !== false) {
             $os->setVersion($os::VERSION_UNKNOWN);
             $os->setName($os::BEOS);
+
             return true;
         }
+
         return false;
     }
 }

--- a/src/Browser/UserAgent.php
+++ b/src/Browser/UserAgent.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser;
 
 class UserAgent
@@ -20,11 +21,13 @@ class UserAgent
 
     /**
      * @param string $userAgentString
+     *
      * @return $this
      */
     public function setUserAgentString($userAgentString)
     {
         $this->userAgentString = $userAgentString;
+
         return $this;
     }
 
@@ -36,6 +39,7 @@ class UserAgent
         if (null === $this->userAgentString) {
             $this->createUserAgentString();
         }
+
         return $this->userAgentString;
     }
 
@@ -46,6 +50,7 @@ class UserAgent
     {
         $userAgentString = isset($_SERVER['HTTP_USER_AGENT']) ? $_SERVER['HTTP_USER_AGENT'] : null;
         $this->setUserAgentString($userAgentString);
+
         return $userAgentString;
     }
 }

--- a/tests/Browser/Tests/AcceptLanguageTest.php
+++ b/tests/Browser/Tests/AcceptLanguageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\AcceptLanguage;
@@ -8,7 +9,7 @@ class AcceptLanguageTest extends PHPUnit_Framework_TestCase
 {
     public function testObject()
     {
-        $acceptLanguage = new AcceptLanguage;
+        $acceptLanguage = new AcceptLanguage();
         $this->assertNull($acceptLanguage->getAcceptLanguageString());
 
         $acceptLanguage = new AcceptLanguage('my_accept_language_string');

--- a/tests/Browser/Tests/BrowserDetectorTest.php
+++ b/tests/Browser/Tests/BrowserDetectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\Browser;

--- a/tests/Browser/Tests/BrowserTest.php
+++ b/tests/Browser/Tests/BrowserTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\Browser;
@@ -9,36 +10,36 @@ class BrowserTest extends PHPUnit_Framework_TestCase
 {
     public function testBlackBerry()
     {
-        $browser = new Browser("BlackBerry8100/4.5.0.124 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/100");
+        $browser = new Browser('BlackBerry8100/4.5.0.124 Profile/MIDP-2.0 Configuration/CLDC-1.1 VendorID/100');
         $this->assertEquals(Browser::BLACKBERRY, $browser->getName());
         $this->assertEquals('4.5.0.124', $browser->getVersion());
     }
 
     public function testFirefox()
     {
-        $browser = new Browser("Mozilla/5.0 (X11; Linux x86_64; rv:18.0) Gecko/20100101 Firefox/18.0");
+        $browser = new Browser('Mozilla/5.0 (X11; Linux x86_64; rv:18.0) Gecko/20100101 Firefox/18.0');
         $this->assertEquals(Browser::FIREFOX, $browser->getName());
         $this->assertEquals('18.0', $browser->getVersion());
     }
 
     public function testInternetExplorer11()
     {
-        $browser = new Browser("Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko");
+        $browser = new Browser('Mozilla/5.0 (Windows NT 6.1; WOW64; Trident/7.0; rv:11.0) like Gecko');
         $this->assertEquals(Browser::IE, $browser->getName());
         $this->assertEquals('11.0', $browser->getVersion());
 
-        $browser = new Browser("Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko");
+        $browser = new Browser('Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0; rv:11.0) like Gecko');
         $this->assertEquals(Browser::IE, $browser->getName());
         $this->assertEquals('11.0', $browser->getVersion());
 
-        $browser = new Browser("Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0;) like Gecko");
+        $browser = new Browser('Mozilla/5.0 (MSIE 9.0; Windows NT 6.3; WOW64; Trident/7.0;) like Gecko');
         $this->assertEquals(Browser::IE, $browser->getName());
         $this->assertEquals('9.0', $browser->getVersion());
     }
 
     public function testSeaMonkey()
     {
-        $browser = new Browser("Mozilla/5.0 (Windows; U; Windows NT 5.1; RW; rv:1.8.0.7) Gecko/20110321 MultiZilla/4.33.2.6a SeaMonkey/8.6.55");
+        $browser = new Browser('Mozilla/5.0 (Windows; U; Windows NT 5.1; RW; rv:1.8.0.7) Gecko/20110321 MultiZilla/4.33.2.6a SeaMonkey/8.6.55');
         $this->assertEquals(Browser::SEAMONKEY, $browser->getName());
         $this->assertEquals('8.6.55', $browser->getVersion());
     }

--- a/tests/Browser/Tests/DeviceDetectorTest.php
+++ b/tests/Browser/Tests/DeviceDetectorTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\Device;
@@ -12,7 +13,7 @@ class DeviceDetectorTest extends PHPUnit_Framework_TestCase
     {
         $userAgentStringCollection = UserAgentStringMapper::map();
 
-        foreach($userAgentStringCollection as $userAgentString) {
+        foreach ($userAgentStringCollection as $userAgentString) {
             $device = new Device();
             $deviceDetector = new DeviceDetector();
             $deviceDetector->setUserAgent(new UserAgent($userAgentString->getString()));
@@ -64,5 +65,4 @@ class DeviceDetectorTest extends PHPUnit_Framework_TestCase
 
         $this->assertEquals($userAgent, $deviceDetector->getUserAgent());
     }
-
 }

--- a/tests/Browser/Tests/DeviceTest.php
+++ b/tests/Browser/Tests/DeviceTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\Device;

--- a/tests/Browser/Tests/LanguageTest.php
+++ b/tests/Browser/Tests/LanguageTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\AcceptLanguage;
@@ -14,7 +15,7 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 
     public function setUp()
     {
-        $httpAcceptLanguage = "fr-CA,fr;q=0.8,en-CA;q=0.6,en;q=0.4,en-US;q=0.2";
+        $httpAcceptLanguage = 'fr-CA,fr;q=0.8,en-CA;q=0.6,en;q=0.4,en-US;q=0.2';
         $this->language = new Language($httpAcceptLanguage);
     }
 
@@ -25,7 +26,7 @@ class LanguageTest extends PHPUnit_Framework_TestCase
 
     public function testGetLanguages()
     {
-        $this->assertGreaterThan(0, sizeof($this->language->getLanguages()));
+        $this->assertGreaterThan(0, count($this->language->getLanguages()));
     }
 
     public function testGetLanguageLocal()
@@ -55,6 +56,4 @@ class LanguageTest extends PHPUnit_Framework_TestCase
         $language = new Language('ru,en-us;q=0.5,en;q=0.3');
         $this->assertEquals('ru', $language->getLanguageLocale());
     }
-
-
 }

--- a/tests/Browser/Tests/OsTest.php
+++ b/tests/Browser/Tests/OsTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\Os;
@@ -10,48 +11,48 @@ class OsTest extends PHPUnit_Framework_TestCase
 {
     public function testIOs()
     {
-        $os = new Os("Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25");
+        $os = new Os('Mozilla/5.0 (iPad; CPU OS 6_0 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) Version/6.0 Mobile/10A5355d Safari/8536.25');
         $this->assertEquals(Os::IOS, $os->getName());
         $this->assertEquals('6.0', $os->getVersion());
     }
 
     public function testOsX()
     {
-        $os = new Os("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.26.17 (KHTML, like Gecko) Version/6.0.2 Safari/536.26.17");
+        $os = new Os('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_8_2) AppleWebKit/536.26.17 (KHTML, like Gecko) Version/6.0.2 Safari/536.26.17');
         $this->assertEquals(Os::OSX, $os->getName());
         $this->assertEquals('10.8.2', $os->getVersion());
     }
 
     public function testOsX1010()
     {
-        $os = new Os("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0");
+        $os = new Os('Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:34.0) Gecko/20100101 Firefox/34.0');
         $this->assertEquals(Os::OSX, $os->getName());
         $this->assertEquals('10.10', $os->getVersion());
     }
 
     public function testBlackberry()
     {
-        $os = new Os("Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+");
+        $os = new Os('Mozilla/5.0 (BlackBerry; U; BlackBerry 9900; en) AppleWebKit/534.11+ (KHTML, like Gecko) Version/7.1.0.346 Mobile Safari/534.11+');
         $this->assertEquals(Os::BLACKBERRY, $os->getName());
         $this->assertEquals(Os::VERSION_UNKNOWN, $os->getVersion());
     }
 
     public function testIsMobile()
     {
-        $os = new Os("Mozilla/5.0 (iPod; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25");
+        $os = new Os('Mozilla/5.0 (iPod; CPU iPhone OS 6_1_3 like Mac OS X) AppleWebKit/536.26 (KHTML, like Gecko) CriOS/28.0.1500.16 Mobile/10B329 Safari/8536.25');
         $this->assertTrue($os->isMobile());
     }
 
     public function testWindows()
     {
-        $os = new Os("Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)");
+        $os = new Os('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)');
         $this->assertEquals(Os::WINDOWS, $os->getName());
         $this->assertEquals('7', $os->getVersion());
     }
 
     public function testConstructor()
     {
-        $userAgent = new UserAgent("Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)");
+        $userAgent = new UserAgent('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)');
         $os = new Os($userAgent);
 
         $this->assertInstanceOf('\Browser\Os', $os);
@@ -67,16 +68,15 @@ class OsTest extends PHPUnit_Framework_TestCase
 
     public function testGetVersion()
     {
-        $userAgent = new UserAgent("Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)");
+        $userAgent = new UserAgent('Mozilla/4.0 (compatible; MSIE 8.0; Windows NT 6.1; WOW64; Trident/4.0; SLCC2; .NET CLR 2.0.50727; .NET CLR 3.5.30729; .NET CLR 3.0.30729; Media Center PC 6.0)');
         $os = new Os($userAgent);
 
         $this->assertEquals('7', $os->getVersion());
     }
 
-
     public function testUnknown()
     {
-        $os = new Os("");
+        $os = new Os('');
         $this->assertEquals(Os::UNKNOWN, $os->getName());
         $this->assertEquals(Os::VERSION_UNKNOWN, $os->getVersion());
     }

--- a/tests/Browser/Tests/UserAgentTest.php
+++ b/tests/Browser/Tests/UserAgentTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use Browser\UserAgent;
@@ -8,7 +9,7 @@ class UserAgentTest extends PHPUnit_Framework_TestCase
 {
     public function testObject()
     {
-        $userAgent = new UserAgent;
+        $userAgent = new UserAgent();
         $this->assertNull($userAgent->getUserAgentString());
 
         $userAgent = new UserAgent('my_agent_user_string');

--- a/tests/Browser/Tests/_includes/UserAgentString.php
+++ b/tests/Browser/Tests/_includes/UserAgentString.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 class UserAgentString
@@ -48,11 +49,13 @@ class UserAgentString
 
     /**
      * @param string $browser
+     *
      * @return $this
      */
     public function setBrowser($browser)
     {
         $this->browser = $browser;
+
         return $this;
     }
 
@@ -66,11 +69,13 @@ class UserAgentString
 
     /**
      * @param string $os
+     *
      * @return $this
      */
     public function setOs($os)
     {
         $this->os = $os;
+
         return $this;
     }
 
@@ -84,11 +89,13 @@ class UserAgentString
 
     /**
      * @param string $osVersion
+     *
      * @return $this
      */
     public function setosVersion($osVersion)
     {
         $this->osVersion = $osVersion;
+
         return $this;
     }
 
@@ -102,11 +109,13 @@ class UserAgentString
 
     /**
      * @param string $string
+     *
      * @return $this
      */
     public function setString($string)
     {
         $this->string = $string;
+
         return $this;
     }
 
@@ -120,11 +129,13 @@ class UserAgentString
 
     /**
      * @param string $browserVersion
+     *
      * @return $this
      */
     public function setbrowserVersion($browserVersion)
     {
         $this->browserVersion = $browserVersion;
+
         return $this;
     }
 
@@ -138,11 +149,13 @@ class UserAgentString
 
     /**
      * @param string $device
+     *
      * @return $this
      */
     public function setDevice($device)
     {
         $this->device = $device;
+
         return $this;
     }
 
@@ -156,11 +169,13 @@ class UserAgentString
 
     /**
      * @param string $deviceVersion
+     *
      * @return $this
      */
     public function setDeviceVersion($deviceVersion)
     {
         $this->deviceVersion = $deviceVersion;
+
         return $this;
     }
 }

--- a/tests/Browser/Tests/_includes/UserAgentStringMapper.php
+++ b/tests/Browser/Tests/_includes/UserAgentStringMapper.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace Browser\Tests;
 
 use SimpleXmlElement;
@@ -11,19 +12,20 @@ class UserAgentStringMapper
     public static function map()
     {
         $collection = array();
-        $xml = new SimpleXmlElement(file_get_contents(FILES . DIRECTORY_SEPARATOR . 'UserAgentStrings.xml'));
+        $xml = new SimpleXmlElement(file_get_contents(FILES.DIRECTORY_SEPARATOR.'UserAgentStrings.xml'));
         foreach ($xml->strings->string as $string) {
             $string = $string->field;
             $userAgentString = new UserAgentString();
-            $userAgentString->setBrowser((string)$string[0]);
-            $userAgentString->setBrowserVersion((string)$string[1]);
-            $userAgentString->setOs((string)$string[2]);
-            $userAgentString->setOsVersion((string)$string[3]);
-            $userAgentString->setDevice((string)$string[4]);
-            $userAgentString->setDeviceVersion((string)$string[5]);
-            $userAgentString->setString(str_replace(array(PHP_EOL, '  '), ' ', (string)$string[6]));
+            $userAgentString->setBrowser((string) $string[0]);
+            $userAgentString->setBrowserVersion((string) $string[1]);
+            $userAgentString->setOs((string) $string[2]);
+            $userAgentString->setOsVersion((string) $string[3]);
+            $userAgentString->setDevice((string) $string[4]);
+            $userAgentString->setDeviceVersion((string) $string[5]);
+            $userAgentString->setString(str_replace(array(PHP_EOL, '  '), ' ', (string) $string[6]));
             $collection[] = $userAgentString;
         }
+
         return $collection;
     }
 }

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,16 +1,16 @@
 <?php
 
-$vendor = realpath(__DIR__ . '/../vendor');
+$vendor = realpath(__DIR__.'/../vendor');
 
-if (file_exists($vendor . "/autoload.php")) {
-    require $vendor . "/autoload.php";
+if (file_exists($vendor.'/autoload.php')) {
+    require $vendor.'/autoload.php';
 } else {
-    $vendor = realpath(__DIR__ . '/../../../');
-    if (file_exists($vendor . "/autoload.php")) {
-        require $vendor . "/autoload.php";
+    $vendor = realpath(__DIR__.'/../../../');
+    if (file_exists($vendor.'/autoload.php')) {
+        require $vendor.'/autoload.php';
     } else {
-        throw new Exception("Unable to load dependencies");
+        throw new Exception('Unable to load dependencies');
     }
 }
 
-define('FILES', __DIR__ . "/Browser/Tests/_files");
+define('FILES', __DIR__.'/Browser/Tests/_files');


### PR DESCRIPTION
In order for this to be accepted by StyleCI you need to add `short_array_syntax` to the disabled configuration on StyleCI's website. Though, I would argue for dropping PHP 5.3 support #30.

Currently StyleCI check fails due to old `array()` syntax.